### PR TITLE
Enforce streaming tests and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2021-10-20
+### Added
+- Added data cleaning
+- Added data streaming functions and unit tests

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -11,7 +11,7 @@
 enforce_streaming <- function(data){
   
   if (class(data) != "data.frame") {
-    stop("Unexpected input: data is not a data.frame.")
+    stop("Unexpected input: data is not a data.frame.")}
   
   data <- enforce_degree_streaming(data)
   data <- enforce_code_freq_streaming(data)

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -1,0 +1,16 @@
+#'@title Enforce degree streaming
+#'
+#'@description Enforce the streaming rules that if highest qualification isn't degree then no degree subject has "Yes" returned 
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_degree_streaming <- function(data){
+  
+  degree_data <- data[grepl("degree_", colnames(data))]
+  degree_data[!is.na(data$highest_qualification) & !(data$highest_qualification %in% c("Bachelor's degree (or equivalent)","Master's degree (or equivalent)","Doctoral degree (or equivalent)")),] <- "No"
+  data[colnames(degree_data)] <- degree_data
+  
+  return(data)
+}

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -14,3 +14,126 @@ enforce_degree_streaming <- function(data){
   
   return(data)
 }
+
+#'@title Enforce code frequency streaming
+#'
+#'@description Enforce the streaming rules that if code frequency is never then multiple questions are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_code_freq_streaming <- function(data){
+  
+  data <- enforce_codefreq_coding_prac(data)
+  data <- enforce_codefreq_doc(data)
+  data <- enforce_codefreq_ci(data)
+  data <- enforce_codefreq_dep_man(data)
+  data <- enforce_codefreq_rep_wf(data)
+  data <- enforce_codefreq_comment(data)
+  
+  return(data)
+  
+}
+
+#'@title Enforce code frequency streaming on coding practices
+#'
+#'@description Enforce the streaming rules that if code frequency is never then coding practices is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_coding_prac <- function(data){
+  
+  coding_prac_data <- dplyr::select(data, use_open_source:AQUA_book)
+  coding_prac_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(coding_prac_data)] <- coding_prac_data
+  
+  return(data)
+}
+
+#'@title Enforce code frequency streaming on documentation questions
+#'
+#'@description Enforce the streaming rules that if code frequency is never then documentation practices is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_doc <- function(data){
+  
+  doc_data <- dplyr::select(data, desk_notes:other_docs)
+  doc_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(doc_data)] <- doc_data
+  
+  return(data)
+}
+
+#'@title Enforce code frequency streaming on continuous integration questions
+#'
+#'@description Enforce the streaming rules that if code frequency is never then continuous integration questions is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_ci <- function(data){
+  
+  ci_data <- data.frame(data$CI)
+  ci_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(ci_data)] <- ci_data
+  
+  return(data)
+}
+
+#'@title Enforce code frequency streaming on dependency management questions
+#'
+#'@description Enforce the streaming rules that if code frequency is never then dependency management questions is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_dep_man <- function(data){
+  
+  dep_man_data <- data.frame(data$dependency_management)
+  dep_man_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(dep_man_data)] <- dep_man_data
+  
+  return(data)
+}
+
+#'@title Enforce code frequency streaming on reproducible workflow questions
+#'
+#'@description Enforce the streaming rules that if code frequency is never then reproducible workflow questions is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_rep_wf <- function(data){
+  
+  rep_wf_data <- data.frame(data$reproducible_workflow)
+  rep_wf_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(rep_wf_data)] <- rep_wf_data
+  
+  return(data)
+}
+
+#'@title Enforce code frequency streaming on extra comment question
+#'
+#'@description Enforce the streaming rules that if code frequency is never then extra comment question is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_codefreq_comment <- function(data){
+  
+  comment_data <- data.frame(data$coding_practices_comments)
+  comment_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
+  data[colnames(comment_data)] <- comment_data
+  
+  return(data)
+}

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -182,3 +182,20 @@ enforce_prev_exp_streaming <- function(data){
   
   return(data)
 }
+
+#'@title Enforce heard of RAP streaming
+#'
+#'@description Enforce the streaming rules that if heard of RAP is "No" then are you RAP_champion and RAP_knowledge are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_heard_of_rap_streaming <- function(data){
+  
+  rap_data <- data[,c("RAP_champion","RAP_knowledge")]
+  rap_data[!is.na(data$heard_of_RAP) & (data$heard_of_RAP %in% c("No")),] <- NA
+  data[colnames(rap_data)] <- rap_data
+  
+  return(data)
+}

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -8,7 +8,10 @@
 #'
 #'@export
 
-Enforce_streaming <- function(data){
+enforce_streaming <- function(data){
+  
+  if (class(data) != "data.frame") {
+    stop("Unexpected input: data is not a data.frame.")
   
   data <- enforce_degree_streaming(data)
   data <- enforce_code_freq_streaming(data)

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -1,3 +1,24 @@
+#'@title API to enforce streaming rules
+#'
+#'@description Enforce all streaming rules across all questions
+#'
+#'@param data pre-processed data
+#'
+#'@return data
+#'
+#'@export
+
+Enforce_streaming <- function(data){
+  
+  data <- enforce_degree_streaming(data)
+  data <- enforce_code_freq_streaming(data)
+  data <- enforce_outside_role_streaming(data)
+  data <- enforce_prev_exp_streaming(data)
+  
+  return(data)
+}
+
+
 #'@title Enforce degree streaming
 #'
 #'@description Enforce the streaming rules that if highest qualification isn't degree then no degree subject has "Yes" returned 
@@ -130,9 +151,26 @@ enforce_codefreq_comment <- function(data){
   return(data)
 }
 
+#'@title Enforce coding experience outside current role streaming
+#'
+#'@description Enforce the streaming rules that if coding experience outside current role is no then follow up questions are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_outside_role_streaming <- function(data){
+  
+  prev_exp_data <- dplyr::select(data, "ability_change":"where_learned_to_code")
+  prev_exp_data[!is.na(data$experience_outside_role) & (data$experience_outside_role %in% c("No")),] <- NA
+  data[colnames(prev_exp_data)] <- prev_exp_data
+  
+  return(data)
+}
+
 #'@title Enforce previous coding experience streaming
 #'
-#'@description Enforce the streaming rules that if previous coding experience is no then follow up questions are skipped
+#'@description Enforce the streaming rules that if previous coding experience is no then where learned to code is skipped
 #'
 #'@param data pre-processed data
 #'
@@ -140,9 +178,7 @@ enforce_codefreq_comment <- function(data){
 
 enforce_prev_exp_streaming <- function(data){
   
-  prev_exp_data <- dplyr::select(data, "ability_change":"where_learned_to_code")
-  prev_exp_data[!is.na(data$experience_outside_role) & (data$experience_outside_role %in% c("No")),] <- NA
-  data[colnames(prev_exp_data)] <- prev_exp_data
+  data$where_learned_to_code[!is.na(data$learn_before_current_role) & (data$learn_before_current_role %in% c("No"))] <- NA
   
   return(data)
 }

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -15,6 +15,7 @@ Enforce_streaming <- function(data){
   data <- enforce_outside_role_streaming(data)
   data <- enforce_prev_exp_streaming(data)
   data <- enforce_heard_of_rap_streaming(data)
+  data <- enforce_rap_champ_streaming(data)
   
   return(data)
 }
@@ -217,9 +218,9 @@ enforce_rap_champ_knowl_streaming <- function(data){
   return(data)
 }
 
-#'@title Enforce heard of RAP streaming on RAP statments
+#'@title Enforce heard of RAP streaming on RAP statements
 #'
-#'@description Enforce the streaming rules that if heard of RAP is "No" then statments on RAP are skipped
+#'@description Enforce the streaming rules that if heard of RAP is "No" then statements on RAP are skipped
 #'
 #'@param data pre-processed data
 #'
@@ -230,6 +231,21 @@ enforce_rap_state_streaming <- function(data){
   statement_data <- dplyr::select(data, "RAP_confident":"RAP_comments")
   statement_data[!is.na(data$heard_of_RAP) & (data$heard_of_RAP %in% c("No")),] <- NA
   data[colnames(statement_data)] <- statement_data
+  
+  return(data)
+}
+
+#'@title Enforce RAP champion streaming
+#'
+#'@description Enforce the streaming rules that if RAP champion is yes then Do you know your RAP champion is skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_rap_champ_streaming <- function(data){
+  
+  data$RAP_knowledge[!is.na(data$RAP_champion) & (data$RAP_champion %in% c("Yes"))] <- NA
   
   return(data)
 }

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -80,9 +80,7 @@ enforce_codefreq_doc <- function(data){
 
 enforce_codefreq_ci <- function(data){
   
-  ci_data <- data.frame(data$CI)
-  ci_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
-  data[colnames(ci_data)] <- ci_data
+  data$CI[!is.na(data$code_freq) & (data$code_freq %in% c("Never"))] <- NA
   
   return(data)
 }
@@ -97,9 +95,7 @@ enforce_codefreq_ci <- function(data){
 
 enforce_codefreq_dep_man <- function(data){
   
-  dep_man_data <- data.frame(data$dependency_management)
-  dep_man_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
-  data[colnames(dep_man_data)] <- dep_man_data
+  data$dependency_management[!is.na(data$code_freq) & (data$code_freq %in% c("Never"))] <- NA
   
   return(data)
 }
@@ -114,9 +110,7 @@ enforce_codefreq_dep_man <- function(data){
 
 enforce_codefreq_rep_wf <- function(data){
   
-  rep_wf_data <- data.frame(data$reproducible_workflow)
-  rep_wf_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
-  data[colnames(rep_wf_data)] <- rep_wf_data
+  data$reproducible_workflow[!is.na(data$code_freq) & (data$code_freq %in% c("Never"))] <- NA
   
   return(data)
 }
@@ -131,9 +125,24 @@ enforce_codefreq_rep_wf <- function(data){
 
 enforce_codefreq_comment <- function(data){
   
-  comment_data <- data.frame(data$coding_practices_comments)
-  comment_data[!is.na(data$code_freq) & (data$code_freq %in% c("Never")),] <- NA
-  data[colnames(comment_data)] <- comment_data
+  data$coding_practices_comments[!is.na(data$code_freq) & (data$code_freq %in% c("Never"))] <- NA
+  
+  return(data)
+}
+
+#'@title Enforce previous coding experience streaming
+#'
+#'@description Enforce the streaming rules that if previous coding experience is no then follow up questions are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_prev_exp_streaming <- function(data){
+  
+  prev_exp_data <- dplyr::select(data, "ability_change":"where_learned_to_code")
+  prev_exp_data[!is.na(data$experience_outside_role) & (data$experience_outside_role %in% c("No")),] <- NA
+  data[colnames(prev_exp_data)] <- prev_exp_data
   
   return(data)
 }

--- a/carsurvey3/R/enforce_streaming.R
+++ b/carsurvey3/R/enforce_streaming.R
@@ -14,6 +14,7 @@ Enforce_streaming <- function(data){
   data <- enforce_code_freq_streaming(data)
   data <- enforce_outside_role_streaming(data)
   data <- enforce_prev_exp_streaming(data)
+  data <- enforce_heard_of_rap_streaming(data)
   
   return(data)
 }
@@ -185,13 +186,29 @@ enforce_prev_exp_streaming <- function(data){
 
 #'@title Enforce heard of RAP streaming
 #'
-#'@description Enforce the streaming rules that if heard of RAP is "No" then are you RAP_champion and RAP_knowledge are skipped
+#'@description Enforce the streaming rules that if heard of RAP is "No" then skip various RAP based questions
 #'
 #'@param data pre-processed data
 #'
 #'@return data frame
 
 enforce_heard_of_rap_streaming <- function(data){
+
+  data <- enforce_rap_champ_knowl_streaming(data)
+  data <- enforce_outside_role_streaming(data)
+
+  return(data)
+}
+
+#'@title Enforce heard of RAP streaming on RAP_champion and RAP_knowledge
+#'
+#'@description Enforce the streaming rules that if heard of RAP is "No" then are you RAP_champion and RAP_knowledge are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_rap_champ_knowl_streaming <- function(data){
   
   rap_data <- data[,c("RAP_champion","RAP_knowledge")]
   rap_data[!is.na(data$heard_of_RAP) & (data$heard_of_RAP %in% c("No")),] <- NA
@@ -199,3 +216,21 @@ enforce_heard_of_rap_streaming <- function(data){
   
   return(data)
 }
+
+#'@title Enforce heard of RAP streaming on RAP statments
+#'
+#'@description Enforce the streaming rules that if heard of RAP is "No" then statments on RAP are skipped
+#'
+#'@param data pre-processed data
+#'
+#'@return data frame
+
+enforce_rap_state_streaming <- function(data){
+  
+  statement_data <- dplyr::select(data, "RAP_confident":"RAP_comments")
+  statement_data[!is.na(data$heard_of_RAP) & (data$heard_of_RAP %in% c("No")),] <- NA
+  data[colnames(statement_data)] <- statement_data
+  
+  return(data)
+}
+

--- a/carsurvey3/R/rename_cols.R
+++ b/carsurvey3/R/rename_cols.R
@@ -125,7 +125,7 @@ rename_cols <- function(data) {
     "flow_charts",
     "other_docs",
     "CI",
-    "depdendency_management",
+    "dependency_management",
     "reproducible_workflow",
     "coding_practices_comments",
     "support_comments",

--- a/carsurvey3/tests/testthat/test-test.R
+++ b/carsurvey3/tests/testthat/test-test.R
@@ -1,4 +1,0 @@
-
-test_that("Function returns TRUE", {
-  expect_true(test())
-})

--- a/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
@@ -26,13 +26,13 @@ dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularl
                          variable_3 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
                          )
 
-expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
                                 desk_notes = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
                                 other_docs = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
                                 variable_3 = dummy_data$variable_3
                                 )
 
-dummy_outcome <- enforce_codefreq_doc(dummy_data)
+dummy_output <- enforce_codefreq_doc(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
@@ -45,13 +45,13 @@ dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularl
                          variable_3 = c("Yes", "No", "I don't know what continuous integration is", "Yes", "No")
                          )
 
-expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
                                 CI = c(NA,  "No", "I don't know what continuous integration is", "Yes", "No"), 
                                 variable_3 = dummy_data$variable_3
                                 )
 
 
-dummy_outcome <- enforce_codefreq_ci(dummy_data)
+dummy_output <- enforce_codefreq_ci(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
@@ -60,17 +60,17 @@ test_that("output values match expected values", {
 #Enforce code frequency streaming on dependency management questions
 
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
-                         depdendency_management = c("Yes", "No", "I don't know what dependency management is", "Yes", "No"), 
+                         dependency_management = c("Yes", "No", "I don't know what dependency management is", "Yes", "No"), 
                          variable_3 = c("Yes", "No", "I don't know what dependency management is", "Yes", "No")
                          )
 
-expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
-                                depdendency_management = c(NA,  "No", "I don't know what dependency management is", "Yes", "No"), 
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
+                                dependency_management = c(NA,  "No", "I don't know what dependency management is", "Yes", "No"), 
                                 variable_3 = dummy_data$variable_3
                                 )
 
 
-dummy_outcome <- enforce_codefreq_dep_man(dummy_data)
+dummy_output <- enforce_codefreq_dep_man(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
@@ -83,13 +83,13 @@ dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularl
                          variable_3 = c("Yes", "No", "I don't know what reproducible workflows are", "Yes", "No")
                          )
 
-expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
                                 reproducible_workflow = c(NA,  "No", "I don't know what reproducible workflows are", "Yes", "No"), 
                                 variable_3 = dummy_data$variable_3
                                 )
 
 
-dummy_outcome <- enforce_codefreq_rep_wf(dummy_data)
+dummy_output <- enforce_codefreq_rep_wf(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
@@ -102,13 +102,13 @@ dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularl
                          variable_3 = c("comment1", "comment2", "comment3", "comment4", "comment5")
                          )
 
-expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
                                 coding_practices_comments = c(NA,  "comment2", "comment3", "comment4", "comment5"), 
                                 variable_3 = dummy_data$variable_3
                                 )
 
 
-dummy_outcome <- enforce_codefreq_comment(dummy_data)
+dummy_output <- enforce_codefreq_comment(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))

--- a/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
@@ -1,16 +1,18 @@
 #Enforce code frequency streaming on coding practices
 
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
-                         use_open_source = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         use_open_source = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"),
+                         version_control = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"),
                          AQUA_book = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
-                         variable_3 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
-                         )
-  
+                         variable_5 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
+)
+
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                use_open_source = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
-                                AQUA_book = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              use_open_source = c(NA, "Regularly", "Sometimes", "Rarely", "Never"),
+                              version_control = c(NA, "Regularly", "Sometimes", "Rarely", "Never"),
+                              AQUA_book = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                              variable_5 = dummy_data$variable_5
+)
 
 dummy_output <- enforce_codefreq_coding_prac(dummy_data)
 
@@ -21,16 +23,18 @@ test_that("output values match expected values", {
 #Enforce code frequency streaming on documentation questions
 
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
-                         desk_notes = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         desk_notes = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"),
+                         version_control = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"),
                          other_docs = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
-                         variable_3 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
-                         )
+                         variable_5 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
+)
 
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                desk_notes = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
-                                other_docs = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              desk_notes = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                              version_control = c(NA, "Regularly", "Sometimes", "Rarely", "Never"),
+                              other_docs = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                              variable_5 = dummy_data$variable_5
+)
 
 dummy_output <- enforce_codefreq_doc(dummy_data)
 
@@ -43,12 +47,12 @@ test_that("output values match expected values", {
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
                          CI = c("Yes", "No", "I don't know what continuous integration is", "Yes", "No"), 
                          variable_3 = c("Yes", "No", "I don't know what continuous integration is", "Yes", "No")
-                         )
+)
 
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                CI = c(NA,  "No", "I don't know what continuous integration is", "Yes", "No"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              CI = c(NA,  "No", "I don't know what continuous integration is", "Yes", "No"), 
+                              variable_3 = dummy_data$variable_3
+)
 
 
 dummy_output <- enforce_codefreq_ci(dummy_data)
@@ -62,12 +66,12 @@ test_that("output values match expected values", {
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
                          dependency_management = c("Yes", "No", "I don't know what dependency management is", "Yes", "No"), 
                          variable_3 = c("Yes", "No", "I don't know what dependency management is", "Yes", "No")
-                         )
+)
 
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                dependency_management = c(NA,  "No", "I don't know what dependency management is", "Yes", "No"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              dependency_management = c(NA,  "No", "I don't know what dependency management is", "Yes", "No"), 
+                              variable_3 = dummy_data$variable_3
+)
 
 
 dummy_output <- enforce_codefreq_dep_man(dummy_data)
@@ -81,12 +85,12 @@ test_that("output values match expected values", {
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
                          reproducible_workflow = c("Yes", "No", "I don't know what reproducible workflows are", "Yes", "No"), 
                          variable_3 = c("Yes", "No", "I don't know what reproducible workflows are", "Yes", "No")
-                         )
+)
 
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                reproducible_workflow = c(NA,  "No", "I don't know what reproducible workflows are", "Yes", "No"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              reproducible_workflow = c(NA,  "No", "I don't know what reproducible workflows are", "Yes", "No"), 
+                              variable_3 = dummy_data$variable_3
+)
 
 
 dummy_output <- enforce_codefreq_rep_wf(dummy_data)
@@ -100,12 +104,12 @@ test_that("output values match expected values", {
 dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
                          coding_practices_comments = c("comment1", "comment2", "comment3", "comment4", "comment5"), 
                          variable_3 = c("comment1", "comment2", "comment3", "comment4", "comment5")
-                         )
+)
 
 expected_output <- data.frame(code_freq = dummy_data$code_freq,
-                                coding_practices_comments = c(NA,  "comment2", "comment3", "comment4", "comment5"), 
-                                variable_3 = dummy_data$variable_3
-                                )
+                              coding_practices_comments = c(NA,  "comment2", "comment3", "comment4", "comment5"), 
+                              variable_3 = dummy_data$variable_3
+)
 
 
 dummy_output <- enforce_codefreq_comment(dummy_data)

--- a/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_code_freq_streaming.R
@@ -1,0 +1,116 @@
+#Enforce code frequency streaming on coding practices
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         use_open_source = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         AQUA_book = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         variable_3 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
+                         )
+  
+expected_output <- data.frame(code_freq = dummy_data$code_freq,
+                                use_open_source = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                                AQUA_book = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+dummy_output <- enforce_codefreq_coding_prac(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+
+#Enforce code frequency streaming on documentation questions
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         desk_notes = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         other_docs = c("All the time", "Regularly", "Sometimes", "Rarely", "Never"), 
+                         variable_3 = c("All the time", "Regularly", "Sometimes", "Rarely", "Never")
+                         )
+
+expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+                                desk_notes = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                                other_docs = c(NA, "Regularly", "Sometimes", "Rarely", "Never"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+dummy_outcome <- enforce_codefreq_doc(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+
+#Enforce code frequency streaming on continuous integration questions
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         CI = c("Yes", "No", "I don't know what continuous integration is", "Yes", "No"), 
+                         variable_3 = c("Yes", "No", "I don't know what continuous integration is", "Yes", "No")
+                         )
+
+expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+                                CI = c(NA,  "No", "I don't know what continuous integration is", "Yes", "No"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+
+dummy_outcome <- enforce_codefreq_ci(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+
+#Enforce code frequency streaming on dependency management questions
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         depdendency_management = c("Yes", "No", "I don't know what dependency management is", "Yes", "No"), 
+                         variable_3 = c("Yes", "No", "I don't know what dependency management is", "Yes", "No")
+                         )
+
+expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+                                depdendency_management = c(NA,  "No", "I don't know what dependency management is", "Yes", "No"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+
+dummy_outcome <- enforce_codefreq_dep_man(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+
+#Enforce code frequency streaming on reproducible workflow questions
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         reproducible_workflow = c("Yes", "No", "I don't know what reproducible workflows are", "Yes", "No"), 
+                         variable_3 = c("Yes", "No", "I don't know what reproducible workflows are", "Yes", "No")
+                         )
+
+expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+                                reproducible_workflow = c(NA,  "No", "I don't know what reproducible workflows are", "Yes", "No"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+
+dummy_outcome <- enforce_codefreq_rep_wf(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+
+#Enforce code frequency streaming on extra comment question
+
+dummy_data <- data.frame(code_freq = c("Never", "Rarely", "Sometimes", "Regularly", "All the time"),
+                         coding_practices_comments = c("comment1", "comment2", "comment3", "comment4", "comment5"), 
+                         variable_3 = c("comment1", "comment2", "comment3", "comment4", "comment5")
+                         )
+
+expected_outcomes <- data.frame(code_freq = dummy_data$code_freq,
+                                coding_practices_comments = c(NA,  "comment2", "comment3", "comment4", "comment5"), 
+                                variable_3 = dummy_data$variable_3
+                                )
+
+
+dummy_outcome <- enforce_codefreq_comment(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})
+

--- a/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
@@ -17,4 +17,6 @@ expected_output <- data.frame(highest_qualification = dummy_data$highest_qualifi
 
 dummy_output <- enforce_degree_streaming(dummy_data)
 
-testthat::expect_true(identical(dummy_output, expected_output))
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})

--- a/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
@@ -6,14 +6,14 @@ dummy_data <- data.frame(highest_qualification = c("Doctoral degree (or equivale
                                                    "test"),
                          degree_maths = c("Yes", "Yes", "No", "Yes", "Yes", "No"),
                          degree_english = c("Yes", "Yes", "No", "Yes", "Yes", "No"),
-                         test = c("Yes", "Yes", "No", "Yes", "Yes", "No")
-                         )
+                         dummy = c("Yes", "Yes", "No", "Yes", "Yes", "No")
+)
 
 expected_output <- data.frame(highest_qualification = dummy_data$highest_qualification,
                               degree_maths = c("Yes", "Yes", "No", "Yes", "No", "No"),
                               degree_english = c("Yes", "Yes", "No", "Yes", "No", "No"),
-                              test = dummy_data$test
-                              )
+                              dummy = dummy_data$dummy
+)
 
 dummy_output <- enforce_degree_streaming(dummy_data)
 

--- a/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_degree_streaming.R
@@ -1,0 +1,20 @@
+dummy_data <- data.frame(highest_qualification = c("Doctoral degree (or equivalent)", 
+                                                   "Master's degree (or equivalent)", 
+                                                   "Bachelor's degree (or equivalent)",
+                                                   NA,
+                                                   "A-level",
+                                                   "test"),
+                         degree_maths = c("Yes", "Yes", "No", "Yes", "Yes", "No"),
+                         degree_english = c("Yes", "Yes", "No", "Yes", "Yes", "No"),
+                         test = c("Yes", "Yes", "No", "Yes", "Yes", "No")
+                         )
+
+expected_output <- data.frame(highest_qualification = dummy_data$highest_qualification,
+                              degree_maths = c("Yes", "Yes", "No", "Yes", "No", "No"),
+                              degree_english = c("Yes", "Yes", "No", "Yes", "No", "No"),
+                              test = dummy_data$test
+                              )
+
+dummy_output <- enforce_degree_streaming(dummy_data)
+
+testthat::expect_true(identical(dummy_output, expected_output))

--- a/carsurvey3/tests/testthat/test_enforce_heard_of_rap_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_heard_of_rap_streaming.R
@@ -1,0 +1,15 @@
+dummy_data <- data.frame(heard_of_RAP = c("Yes", "No"), 
+                         RAP_champion = c("No", "Yes"),
+                         RAP_knowledge = c("I know who the RAP champion in my department is",
+                                           "I don't know what a RAP champion is"))
+
+expected_output <- data.frame(heard_of_RAP = dummy_data$heard_of_RAP, 
+                            RAP_champion = c("No", NA),
+                            RAP_knowledge = c("I know who the RAP champion in my department is",
+                                              NA))
+
+dummy_output <- enforce_heard_of_rap_streaming(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})

--- a/carsurvey3/tests/testthat/test_enforce_outside_role_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_outside_role_streaming.R
@@ -1,0 +1,17 @@
+dummy_data <- data.frame(experience_outside_role = c("No", "Yes"), 
+                         ability_change = c("Significantly worse", "Significantly better"), 
+                         learn_before_current_role = c("Yes", "No"), 
+                         where_learned_to_code = c("In public sector employment", "Self-taught"),
+                         dummy_variable = c("dummy1", "dummy2"))
+  
+expected_output <- data.frame(experience_outside_role = c("No", "Yes"), 
+                              ability_change = c(NA, "Significantly better"), 
+                              learn_before_current_role = c(NA, "No"), 
+                              where_learned_to_code = c(NA, "Self-taught"),
+                              dummy_variable = c("dummy1", "dummy2"))
+  
+dummy_output <- enforce_outside_role_streaming(dummy_data)
+  
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})

--- a/carsurvey3/tests/testthat/test_enforce_outside_role_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_outside_role_streaming.R
@@ -3,15 +3,15 @@ dummy_data <- data.frame(experience_outside_role = c("No", "Yes"),
                          learn_before_current_role = c("Yes", "No"), 
                          where_learned_to_code = c("In public sector employment", "Self-taught"),
                          dummy_variable = c("dummy1", "dummy2"))
-  
+
 expected_output <- data.frame(experience_outside_role = c("No", "Yes"), 
                               ability_change = c(NA, "Significantly better"), 
                               learn_before_current_role = c(NA, "No"), 
                               where_learned_to_code = c(NA, "Self-taught"),
                               dummy_variable = c("dummy1", "dummy2"))
-  
+
 dummy_output <- enforce_outside_role_streaming(dummy_data)
-  
+
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
 })

--- a/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
@@ -1,0 +1,17 @@
+dummy_data <- data.frame(experience_outside_role = c("No", "Yes"), 
+                         ability_change = c("Significantly worse", "Significantly better"), 
+                         learn_before_current_role = c("Yes", "No"), 
+                         where_learned_to_code = c("In public sector employment", "Self-taught"),
+                         dummy_variable = c("dummy1", "dummy2"))
+  
+expected_output <- data.frame(experience_outside_role = c("No", "Yes"), 
+                              ability_change = c(NA, "Significantly better"), 
+                              learn_before_current_role = c(NA, "No"), 
+                              where_learned_to_code = c(NA, "Self-taught"),
+                              dummy_variable = c("dummy1", "dummy2"))
+  
+dummy_output <- enforce_prev_exp_streaming(dummy_data)
+  
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})

--- a/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
@@ -1,17 +1,11 @@
-dummy_data <- data.frame(experience_outside_role = c("No", "Yes"), 
-                         ability_change = c("Significantly worse", "Significantly better"), 
-                         learn_before_current_role = c("Yes", "No"), 
-                         where_learned_to_code = c("In public sector employment", "Self-taught"),
-                         dummy_variable = c("dummy1", "dummy2"))
+dummy_data <- data.frame(learn_before_current_role = c("No", "Yes"),
+                         where_learned_to_code = c("Self-taught", "In education"))
   
-expected_output <- data.frame(experience_outside_role = c("No", "Yes"), 
-                              ability_change = c(NA, "Significantly better"), 
-                              learn_before_current_role = c(NA, "No"), 
-                              where_learned_to_code = c(NA, "Self-taught"),
-                              dummy_variable = c("dummy1", "dummy2"))
-  
+expected_output <- data.frame(learn_before_current_role = dummy_data$learn_before_current_role,
+                              where_learned_to_code = c(NA, "In education"))
+
 dummy_output <- enforce_prev_exp_streaming(dummy_data)
-  
+
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))
 })

--- a/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_prev_exp_streaming.R
@@ -1,8 +1,10 @@
 dummy_data <- data.frame(learn_before_current_role = c("No", "Yes"),
-                         where_learned_to_code = c("Self-taught", "In education"))
-  
+                         where_learned_to_code = c("Self-taught", "In education"),
+                         dummy = c("dummy1", "dummy2"))
+
 expected_output <- data.frame(learn_before_current_role = dummy_data$learn_before_current_role,
-                              where_learned_to_code = c(NA, "In education"))
+                              where_learned_to_code = c(NA, "In education"),
+                              dummy = c("dummy1", "dummy2"))
 
 dummy_output <- enforce_prev_exp_streaming(dummy_data)
 

--- a/carsurvey3/tests/testthat/test_enforce_rap_champ_knowl_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_champ_knowl_streaming.R
@@ -1,12 +1,14 @@
 dummy_data <- data.frame(heard_of_RAP = c("Yes", "No"), 
                          RAP_champion = c("No", "Yes"),
                          RAP_knowledge = c("I know who the RAP champion in my department is",
-                                           "I don't know what a RAP champion is"))
+                                           "I don't know what a RAP champion is"),
+                         dummy = c("dummy1", "dummy2"))
 
 expected_output <- data.frame(heard_of_RAP = dummy_data$heard_of_RAP, 
-                            RAP_champion = c("No", NA),
-                            RAP_knowledge = c("I know who the RAP champion in my department is",
-                                              NA))
+                              RAP_champion = c("No", NA),
+                              RAP_knowledge = c("I know who the RAP champion in my department is",
+                                                NA),
+                              dummy = c("dummy1", "dummy2"))
 
 dummy_output <- enforce_rap_champ_knowl_streaming(dummy_data)
 

--- a/carsurvey3/tests/testthat/test_enforce_rap_champ_knowl_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_champ_knowl_streaming.R
@@ -8,7 +8,7 @@ expected_output <- data.frame(heard_of_RAP = dummy_data$heard_of_RAP,
                             RAP_knowledge = c("I know who the RAP champion in my department is",
                                               NA))
 
-dummy_output <- enforce_heard_of_rap_streaming(dummy_data)
+dummy_output <- enforce_rap_champ_knowl_streaming(dummy_data)
 
 test_that("output values match expected values", {
   expect_true(identical(dummy_output, expected_output))

--- a/carsurvey3/tests/testthat/test_enforce_rap_champ_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_champ_streaming.R
@@ -1,12 +1,14 @@
 dummy_data <- data.frame(RAP_champion = c("Yes", "No"), 
                          RAP_knowledge = c("I know who the RAP champion in my department is",
-                                           "I don't know what a RAP champion is")
-                         )
+                                           "I don't know what a RAP champion is"),
+                         dummy = c("dummy1", "dummy2")
+)
 
 expected_output <- data.frame(RAP_champion = c("Yes", "No"), 
-                            RAP_knowledge = c(NA,
-                                              "I don't know what a RAP champion is")
-                            )
+                              RAP_knowledge = c(NA,
+                                                "I don't know what a RAP champion is"),
+                              dummy = c("dummy1", "dummy2")
+)
 
 dummy_output <- enforce_rap_champ_streaming(dummy_data)
 

--- a/carsurvey3/tests/testthat/test_enforce_rap_champ_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_champ_streaming.R
@@ -1,0 +1,15 @@
+dummy_data <- data.frame(RAP_champion = c("Yes", "No"), 
+                         RAP_knowledge = c("I know who the RAP champion in my department is",
+                                           "I don't know what a RAP champion is")
+                         )
+
+expected_output <- data.frame(RAP_champion = c("Yes", "No"), 
+                            RAP_knowledge = c(NA,
+                                              "I don't know what a RAP champion is")
+                            )
+
+dummy_output <- enforce_rap_champ_streaming(dummy_data)
+
+test_that("output values match expected values", {
+  expect_true(identical(dummy_output, expected_output))
+})

--- a/carsurvey3/tests/testthat/test_enforce_rap_state_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_state_streaming.R
@@ -6,19 +6,21 @@ dummy_data <- data.frame(heard_of_RAP = c("Yes", "No"),
                          RAP_important = c("Strongly Agree", "Strongly Disagree"), 
                          RAP_implementing = c("Strongly Agree", "Strongly Disagree"), 
                          RAP_planning_to_implement = c("Strongly Agree", "Strongly Disagree"),
-                         RAP_comments = c("Strongly Agree", "Strongly Disagree")
-                         )
+                         RAP_comments = c("Strongly Agree", "Strongly Disagree"),
+                         dummy = c("dummy1", "dummy2")
+)
 
 expected_output <- data.frame(heard_of_RAP = c("Yes", "No"),
-                         RAP_confident = c("Strongly Agree", NA),
-                         RAP_supported = c("Strongly Agree", NA),
-                         RAP_resources = c("Strongly Agree", NA),
-                         RAP_understand_key_components = c("Strongly Agree", NA),
-                         RAP_important = c("Strongly Agree", NA), 
-                         RAP_implementing = c("Strongly Agree", NA), 
-                         RAP_planning_to_implement = c("Strongly Agree", NA),
-                         RAP_comments = c("Strongly Agree", NA)
-                         )
+                              RAP_confident = c("Strongly Agree", NA),
+                              RAP_supported = c("Strongly Agree", NA),
+                              RAP_resources = c("Strongly Agree", NA),
+                              RAP_understand_key_components = c("Strongly Agree", NA),
+                              RAP_important = c("Strongly Agree", NA), 
+                              RAP_implementing = c("Strongly Agree", NA), 
+                              RAP_planning_to_implement = c("Strongly Agree", NA),
+                              RAP_comments = c("Strongly Agree", NA),
+                              dummy = c("dummy1", "dummy2")
+)
 
 dummy_output <- enforce_rap_state_streaming(dummy_data)
 

--- a/carsurvey3/tests/testthat/test_enforce_rap_state_streaming.R
+++ b/carsurvey3/tests/testthat/test_enforce_rap_state_streaming.R
@@ -1,0 +1,27 @@
+dummy_data <- data.frame(heard_of_RAP = c("Yes", "No"),
+                         RAP_confident = c("Strongly Agree", "Strongly Disagree"),
+                         RAP_supported = c("Strongly Agree", "Strongly Disagree"),
+                         RAP_resources = c("Strongly Agree", "Strongly Disagree"),
+                         RAP_understand_key_components = c("Strongly Agree", "Strongly Disagree"),
+                         RAP_important = c("Strongly Agree", "Strongly Disagree"), 
+                         RAP_implementing = c("Strongly Agree", "Strongly Disagree"), 
+                         RAP_planning_to_implement = c("Strongly Agree", "Strongly Disagree"),
+                         RAP_comments = c("Strongly Agree", "Strongly Disagree")
+                         )
+
+expected_output <- data.frame(heard_of_RAP = c("Yes", "No"),
+                         RAP_confident = c("Strongly Agree", NA),
+                         RAP_supported = c("Strongly Agree", NA),
+                         RAP_resources = c("Strongly Agree", NA),
+                         RAP_understand_key_components = c("Strongly Agree", NA),
+                         RAP_important = c("Strongly Agree", NA), 
+                         RAP_implementing = c("Strongly Agree", NA), 
+                         RAP_planning_to_implement = c("Strongly Agree", NA),
+                         RAP_comments = c("Strongly Agree", NA)
+                         )
+
+dummy_output <- enforce_rap_state_streaming(dummy_data)
+
+test_that("Check dummy_output and expected_output are identical",{
+  expect_true(identical(dummy_output, expected_output))
+})


### PR DESCRIPTION
I created unit tests and then functions for each of the streaming lines. the functions are in R/enforce_streaming with an API at the top each function has a unit test (excluding the API function).  Take a look and me know if any further detail is required. 

I added the validation check to the API rather than each of the individual tests, unsure if this is best practice.